### PR TITLE
🔒 fix: add authorization checks for vehicle deletion

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -61,6 +61,7 @@ Config = Config or {}
 Config.TrackVehicleByPlateCommand = 'trackvehicle'
 Config.EnableTrackVehicleByPlateCommand = true -- Allow players to track their vehicles by plate using /trackvehicle <plate>
 Config.TrackVehicleByPlateCommandPermissionLevel = 'god' -- Permission level required to use /trackvehicle <plate>, false for anyone / everyone
+Config.ManageVehiclesPermissionLevel = 'admin' -- Permission level required to use /pgarage and /deletevehicle
 
 -- NEW --
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -55,14 +55,16 @@ QBCore.Commands.Add("pgarage", "Player's Vehicles", {}, false, function(source, 
             TriggerClientEvent('qb-garages:client:openmanage', src, pname, menuoptions)
         end
     end
-end)
+end, Config.ManageVehiclesPermissionLevel)
 
 QBCore.Commands.Add("deletevehicle", "Delete a vehicle with plate", {}, false, function(source, args)
     TriggerEvent('qb-garages:server:deletecar', args[1])
-end)
+end, Config.ManageVehiclesPermissionLevel)
 
 RegisterNetEvent('qb-garages:server:deletecar', function (plate)
     local src = source
+    if not QBCore.Functions.HasPermission(src, Config.ManageVehiclesPermissionLevel) then return end
+    if not plate or type(plate) ~= "string" then return end
     MySQL.query('SELECT * FROM player_vehicles WHERE plate = ?', {plate}, function(result)
         if result[1] then
             MySQL.query('DELETE FROM player_vehicles WHERE plate = ?', {plate}, function(results)


### PR DESCRIPTION
🎯 **What:** This PR fixes a missing authorization vulnerability in the vehicle deletion functionality of the `qb-garages` resource.

⚠️ **Risk:** Without this fix, malicious clients could trigger the `qb-garages:server:deletecar` server event directly, allowing them to delete any player's vehicle from the database by guessing or discovering its license plate.

🛡️ **Solution:** 
- A new configurable permission level `Config.ManageVehiclesPermissionLevel` (defaulting to 'admin') was added to `config.lua`.
- The administrative commands `/pgarage` and `/deletevehicle` were updated to require this permission level.
- The `qb-garages:server:deletecar` NetEvent handler was updated to perform a server-side permission check using `QBCore.Functions.HasPermission`.
- Basic input validation was added to ensure the `plate` argument is a valid string before proceeding with database operations.

---
*PR created automatically by Jules for task [13209937846289889618](https://jules.google.com/task/13209937846289889618) started by @thesolitudetr*