### PR TITLE
🧹 [code health improvement] Remove commented-out GetCarDamage function

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -323,34 +323,6 @@ local function ApplyVehicleDamage(currentVehicle, veh)
     SetVehicleBodyHealth(currentVehicle, body)
 end
 
---[[ local function GetCarDamage(vehicle) -- Not Used
-    local damage = {
-        windows = {},
-        tyres = {},
-        doors = {}
-    }
-    local tyreIndexes = {0, 1, 2, 3, 4, 5, 45, 47}
-
-    for _, i in pairs(tyreIndexes) do
-        damage.tyres[i] = {
-            burst = IsVehicleTyreBurst(vehicle, i, false) == 1,
-            onRim = IsVehicleTyreBurst(vehicle, i, true) == 1,
-            health = GetTyreHealth(vehicle, i)
-        }
-    end
-    for i = 0, 7 do
-        damage.windows[i] = {
-            smashed = not IsVehicleWindowIntact(vehicle, i)
-        }
-    end
-    for i = 0, 5 do
-        damage.doors[i] = {
-            damaged = IsVehicleDoorDamaged(vehicle, i)
-        }
-    end
-    return damage
-end ]]
-
 local function Round(num, numDecimalPlaces)
     return tonumber(string.format("%." .. (numDecimalPlaces or 0) .. "f", num))
 end


### PR DESCRIPTION
🎯 **What:** The commented-out `GetCarDamage` function in `client/main.lua` was removed.
💡 **Why:** This function was explicitly marked as "Not Used" and was commented out. Removing it improves the maintainability and readability of the codebase by eliminating dead code.
✅ **Verification:** I confirmed that the code was indeed commented out and not used elsewhere in the repository using `grep`. I also manually verified the syntax of `client/main.lua` after the deletion.
✨ **Result:** A cleaner and more maintainable `client/main.lua` file.

---
*PR created automatically by Jules for task [12362703116062065873](https://jules.google.com/task/12362703116062065873) started by @thesolitudetr*