### PR TITLE
🧹 [code health improvement] Remove dead code blocks in client/main.lua

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -188,42 +188,6 @@ end
 -- Menus
 
 --Old menu
---[[ local function PublicGarage(garageName, type)
-    local garage = Config.Garages[garageName]
-    local categories = garage.vehicleCategories
-    local superCategory = GetSuperCategoryFromCategories(categories)
-
-    lib.registerContext({
-            id = 'vehicles_menu',
-            title = garage.label,
-            options = {
-            {
-                title = Lang:t("menu.text.vehicles"),
-                icon = 'car',
-                onSelect = function()
-                    local args = {
-                        garageId = garageName,
-                        garage = garage,
-                        categories = categories,
-                        header = Lang:t("menu.header." .. garage.type .. "_" .. superCategory, {
-                            value = garage.label
-                        }),
-                        superCategory = superCategory,
-                        type = type
-                    }
-                    TriggerEvent('qb-garages:client:GarageMenu', args)
-                end,
-            },
-            {
-                title = Lang:t("menu.leave.car"),
-                onSelect = function () return end
-            }
-        }
-    })
-
-    lib.showContext('vehicles_menu')
-end ]]
-
 local function PublicGarage(garageName, type)
     local garage = Config.Garages[garageName]
     local categories = garage.vehicleCategories
@@ -241,38 +205,6 @@ local function PublicGarage(garageName, type)
     }
     TriggerEvent('qb-garages:client:GarageMenu', args)
 end
-
---[[ local function MenuHouseGarage()
-    local superCategory = GetSuperCategoryFromCategories(Config.HouseGarageCategories)
-
-    lib.registerContext({
-        id = 'vehicles_menu',
-        title = Lang:t("menu.header.house_garage"),
-        options = {
-            {
-                title = Lang:t("menu.text.vehicles"),
-                icon = 'car',
-                onSelect = function()
-                    local args = {
-                        garageId = CurrentHouseGarage,
-                        categories = Config.HouseGarageCategories,
-                        header = Config.HouseGarages[CurrentHouseGarage].label,
-                        garage = Config.HouseGarages[CurrentHouseGarage],
-                        superCategory = superCategory,
-                        type = 'house'
-                    }
-                    TriggerEvent('qb-garages:client:GarageMenu', args)
-                end,
-            },
-            {
-                title = Lang:t("menu.leave.car"),
-                onSelect = function () return end
-            }
-        }
-    })
-
-    lib.showContext('vehicles_menu')
-end ]]
 
 local function MenuHouseGarage()
     local superCategory = GetSuperCategoryFromCategories(Config.HouseGarageCategories)
@@ -322,34 +254,6 @@ local function ApplyVehicleDamage(currentVehicle, veh)
     SetVehicleEngineHealth(currentVehicle, engine)
     SetVehicleBodyHealth(currentVehicle, body)
 end
-
---[[ local function GetCarDamage(vehicle) -- Not Used
-    local damage = {
-        windows = {},
-        tyres = {},
-        doors = {}
-    }
-    local tyreIndexes = {0, 1, 2, 3, 4, 5, 45, 47}
-
-    for _, i in pairs(tyreIndexes) do
-        damage.tyres[i] = {
-            burst = IsVehicleTyreBurst(vehicle, i, false) == 1,
-            onRim = IsVehicleTyreBurst(vehicle, i, true) == 1,
-            health = GetTyreHealth(vehicle, i)
-        }
-    end
-    for i = 0, 7 do
-        damage.windows[i] = {
-            smashed = not IsVehicleWindowIntact(vehicle, i)
-        }
-    end
-    for i = 0, 5 do
-        damage.doors[i] = {
-            damaged = IsVehicleDoorDamaged(vehicle, i)
-        }
-    end
-    return damage
-end ]]
 
 local function Round(num, numDecimalPlaces)
     return tonumber(string.format("%." .. (numDecimalPlaces or 0) .. "f", num))


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code blocks from `client/main.lua` (`PublicGarage`, `MenuHouseGarage`, and `GetCarDamage`).
💡 **Why:** To improve code readability and maintainability by cleaning up unnecessary, obsolete code blocks that cluttered the file.
✅ **Verification:** Verified via `git diff` that only dead code was removed, and ran a Python script to ensure that the removed blocks didn't introduce unmatched braces or parentheses, confirming the syntax remains valid.
✨ **Result:** A cleaner, more maintainable `client/main.lua` file without dead code comments.

---
*PR created automatically by Jules for task [5779757935445081477](https://jules.google.com/task/5779757935445081477) started by @thesolitudetr*