### PR TITLE
🔒 Fix missing authorization on parkVehicle

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -644,10 +644,30 @@ RegisterNetEvent('qb-garage:server:PayDepotPrice', function(data)
 end)
 
 RegisterNetEvent('qb-garages:server:parkVehicle', function(plate)
+    local src = source
+    if type(plate) ~= 'string' then return end
     plate = string.upper(plate)
+
     local vehicle = GetVehicleByPlate(plate)
-    if vehicle then
+    if not vehicle then return end
+
+    local ped = GetPlayerPed(src)
+    local pedCoords = GetEntityCoords(ped)
+    local vehCoords = GetEntityCoords(vehicle)
+
+    if #(pedCoords - vehCoords) > 10.0 then return end
+
+    local pData = QBCore.Functions.GetPlayer(src)
+    if not pData then return end
+
+    if VehicleSpawnerVehicles[plate] then
         DeleteEntity(vehicle)
+    else
+        MySQL.query('SELECT * FROM player_vehicles WHERE plate = ? AND citizenid = ?', {plate, pData.PlayerData.citizenid}, function(result)
+            if result[1] then
+                DeleteEntity(vehicle)
+            end
+        end)
     end
 end)
 


### PR DESCRIPTION
🎯 **What:** The `qb-garages:server:parkVehicle` event was missing distance and ownership checks.
⚠️ **Risk:** Any player could trigger this event remotely with any license plate, leading to severe server-wide griefing by deleting other players' vehicles regardless of distance or ownership.
🛡️ **Solution:** Added server-side validation. The patch now validates the input type, checks the distance between the player and the vehicle (must be < 10.0 units), and verifies ownership via the `player_vehicles` database or `VehicleSpawnerVehicles` map. It also includes a necessary check for the player object existence (`pData`) to avoid runtime exceptions on edge cases.

---
*PR created automatically by Jules for task [15204267194741810350](https://jules.google.com/task/15204267194741810350) started by @thesolitudetr*